### PR TITLE
Himankpathak's GitHub updated at

### DIFF
--- a/actions/issues.go
+++ b/actions/issues.go
@@ -70,7 +70,7 @@ func (v IssuesResource) ListOpen(c buffalo.Context) error {
 
 	if len(*issues) < 1 {
 		//TODO: send error to a logger package which will ignore it if nil
-		if err := q.Where(whereClause).All(issues).Order("github_updated_at desc"); err != nil {
+		if err := q.Where(whereClause).Order("github_updated_at desc").All(issues); err != nil {
 			return errors.WithStack(err)
 		}
 		jsonIssues, err := json.Marshal(issues)
@@ -108,7 +108,7 @@ func (v IssuesResource) List(c buffalo.Context) error {
 	q := tx.PaginateFromParams(params).Eager()
 
 	// Retrieve all Issues from the DB
-	if err := q.All(issues).Order("github_updated_at desc"); err != nil {
+	if err := q.Order("github_updated_at desc").All(issues); err != nil {
 		return errors.WithStack(err)
 	}
 	c.Set("pagination", q.Paginator)

--- a/actions/issues.go
+++ b/actions/issues.go
@@ -38,7 +38,7 @@ func (v IssuesResource) ListOpen(c buffalo.Context) error {
 		}
 	}
 	// Retrieve all Issues from the DB
-	if err := q.Where(whereClause).All(issues); err != nil {
+	if err := q.Where(whereClause).All(issues).Order("github_updated_at desc"); err != nil {
 		return errors.WithStack(err)
 	}
 	c.Set("pagination", q.Paginator)
@@ -62,7 +62,7 @@ func (v IssuesResource) List(c buffalo.Context) error {
 	q := tx.PaginateFromParams(params).Eager()
 
 	// Retrieve all Issues from the DB
-	if err := q.All(issues); err != nil {
+	if err := q.All(issues).Order("github_updated_at desc"); err != nil {
 		return errors.WithStack(err)
 	}
 	c.Set("pagination", q.Paginator)

--- a/actions/issues.go
+++ b/actions/issues.go
@@ -70,7 +70,7 @@ func (v IssuesResource) ListOpen(c buffalo.Context) error {
 
 	if len(*issues) < 1 {
 		//TODO: send error to a logger package which will ignore it if nil
-		if err := q.Where(whereClause).All(issues); err != nil {
+		if err := q.Where(whereClause).All(issues).Order("github_updated_at desc"); err != nil {
 			return errors.WithStack(err)
 		}
 		jsonIssues, err := json.Marshal(issues)
@@ -108,7 +108,7 @@ func (v IssuesResource) List(c buffalo.Context) error {
 	q := tx.PaginateFromParams(params).Eager()
 
 	// Retrieve all Issues from the DB
-	if err := q.All(issues); err != nil {
+	if err := q.All(issues).Order("github_updated_at desc"); err != nil {
 		return errors.WithStack(err)
 	}
 	c.Set("pagination", q.Paginator)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gobuffalo/envy v1.7.0
 	github.com/gobuffalo/flect v0.1.6 // indirect
 	github.com/gobuffalo/mw-contenttype v0.0.0-20190224202710-36c73cc938f3
-	github.com/gobuffalo/mw-csrf v0.0.0-20190129204204-25460a055517 // indirect
 	github.com/gobuffalo/mw-paramlogger v0.0.0-20190224201358-0d45762ab655
 	github.com/gobuffalo/mw-tokenauth v0.0.0-20190224160709-de0b19e98543
 	github.com/gobuffalo/nulls v0.1.0

--- a/migrations/20190313142702_add_github_updated_at_to_issues.down.fizz
+++ b/migrations/20190313142702_add_github_updated_at_to_issues.down.fizz
@@ -1,0 +1,2 @@
+sql("ALTER TABLE public.issues
+REMOVE COLUMN github_updated_at timestamp without time zone")

--- a/migrations/20190313142702_add_github_updated_at_to_issues.down.fizz
+++ b/migrations/20190313142702_add_github_updated_at_to_issues.down.fizz
@@ -1,2 +1,1 @@
-sql("ALTER TABLE public.issues
-REMOVE COLUMN github_updated_at timestamp without time zone")
+drop_column("issues", "github_updated_at")

--- a/migrations/20190313142702_add_github_updated_at_to_issues.up.fizz
+++ b/migrations/20190313142702_add_github_updated_at_to_issues.up.fizz
@@ -1,0 +1,2 @@
+sql("ALTER TABLE public.issues
+ADD COLUMN github_updated_at timestamp without time zone")

--- a/migrations/20190313142702_add_github_updated_at_to_issues.up.fizz
+++ b/migrations/20190313142702_add_github_updated_at_to_issues.up.fizz
@@ -1,2 +1,1 @@
-sql("ALTER TABLE public.issues
-ADD COLUMN github_updated_at timestamp without time zone")
+add_column("issues", "github_updated_at", "timestamptz", {})

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -56,7 +56,8 @@ CREATE TABLE public.issues (
     project_id uuid NOT NULL,
     closed boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    github_updated_at timestamp with time zone NOT NULL
 );
 
 

--- a/models/issue.go
+++ b/models/issue.go
@@ -15,6 +15,7 @@ type Issue struct {
 	ID               uuid.UUID     `json:"id" db:"id"`
 	CreatedAt        time.Time     `json:"created_at" db:"created_at"`
 	UpdatedAt        time.Time     `json:"updated_at" db:"updated_at"`
+	GithubUpdatedAt  time.time		 `json:"github_updated_at" db:"github_updated_at"`
 	Title            nulls.String  `json:"title" db:"title"`
 	ExperienceNeeded nulls.String  `json:"experience_needed" db:"experience_needed"`
 	ExpectedTime     nulls.String  `json:"expected_time" db:"expected_time"`

--- a/models/issue.go
+++ b/models/issue.go
@@ -15,7 +15,7 @@ type Issue struct {
 	ID               uuid.UUID     `json:"id" db:"id"`
 	CreatedAt        time.Time     `json:"created_at" db:"created_at"`
 	UpdatedAt        time.Time     `json:"updated_at" db:"updated_at"`
-	GithubUpdatedAt  time.time		 `json:"github_updated_at" db:"github_updated_at"`
+	GithubUpdatedAt  time.time     `json:"github_updated_at" db:"github_updated_at"`
 	Title            nulls.String  `json:"title" db:"title"`
 	ExperienceNeeded nulls.String  `json:"experience_needed" db:"experience_needed"`
 	ExpectedTime     nulls.String  `json:"expected_time" db:"expected_time"`

--- a/models/issue.go
+++ b/models/issue.go
@@ -15,7 +15,7 @@ type Issue struct {
 	ID               uuid.UUID     `json:"id" db:"id"`
 	CreatedAt        time.Time     `json:"created_at" db:"created_at"`
 	UpdatedAt        time.Time     `json:"updated_at" db:"updated_at"`
-	GithubUpdatedAt  time.time     `json:"github_updated_at" db:"github_updated_at"`
+	GithubUpdatedAt  time.Time     `json:"github_updated_at" db:"github_updated_at"`
 	Title            nulls.String  `json:"title" db:"title"`
 	ExperienceNeeded nulls.String  `json:"experience_needed" db:"experience_needed"`
 	ExpectedTime     nulls.String  `json:"expected_time" db:"expected_time"`

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -40,6 +40,7 @@ type (
 			Number     int
 			URL        string
 			CreatedAt  string
+			UpdatedAt  string
 			DatabaseID int
 			Labels     struct {
 				Nodes []struct {
@@ -331,6 +332,16 @@ func (w *Worker) getExtraIssues(name, owner *githubv4.String, before *string, re
 
 }
 
+// Parse string to time.Time
+func timeConvert(GHUpdatedTime string) time.Time {
+	layout := "2006-01-02T15:04:05"
+	t, err := time.Parse(layout, GHUpdatedTime)
+	if err != nil {
+	    fmt.Println(err)
+	}
+	return t
+}
+
 // Parse and save github issues
 func (w *Worker) parseAndSaveIssues(issueData issueQueryWithBefore, repository *models.Repository, language *string, hasPreviousPage bool) {
 	issuesToCreate := models.Issues{}
@@ -346,6 +357,7 @@ func (w *Worker) parseAndSaveIssues(issueData issueQueryWithBefore, repository *
 			RepositoryID: repository.ID,
 			ProjectID:    repository.ProjectID,
 			Language:     nulls.String{String: strings.ToLower(*language), Valid: *language != ""},
+			GithubUpdatedAt: timeConvert(node.UpdatedAt),
 		}
 
 		// Parse github labels

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -334,10 +334,9 @@ func (w *Worker) getExtraIssues(name, owner *githubv4.String, before *string, re
 
 // Parse string to time.Time
 func timeConvert(GHUpdatedTime string) time.Time {
-	layout := "2006-01-02T15:04:05Z"
-	t, err := time.Parse(layout, GHUpdatedTime)
+	t, err := time.Parse(time.RFC3339, GHUpdatedTime)
 	if err != nil {
-	    fmt.Println(err)
+		fmt.Println(err)
 	}
 	return t
 }
@@ -348,15 +347,15 @@ func (w *Worker) parseAndSaveIssues(issueData issueQueryWithBefore, repository *
 	issuesToUpdate := models.Issues{}
 	for _, node := range issueData.Repository.Issues.Nodes {
 		githubIssue := &models.Issue{
-			GithubID:     node.DatabaseID,
-			Body:         nulls.String{String: node.Body, Valid: node.Body != ""},
-			Title:        nulls.String{String: node.Title, Valid: node.Title != ""},
-			Closed:       node.Closed,
-			Number:       node.Number,
-			URL:          node.URL,
-			RepositoryID: repository.ID,
-			ProjectID:    repository.ProjectID,
-			Language:     nulls.String{String: strings.ToLower(*language), Valid: *language != ""},
+			GithubID:        node.DatabaseID,
+			Body:            nulls.String{String: node.Body, Valid: node.Body != ""},
+			Title:           nulls.String{String: node.Title, Valid: node.Title != ""},
+			Closed:          node.Closed,
+			Number:          node.Number,
+			URL:             node.URL,
+			RepositoryID:    repository.ID,
+			ProjectID:       repository.ProjectID,
+			Language:        nulls.String{String: strings.ToLower(*language), Valid: *language != ""},
 			GithubUpdatedAt: timeConvert(node.UpdatedAt),
 		}
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -37,6 +37,7 @@ type (
 			Number     int
 			URL        string
 			CreatedAt  string
+			UpdatedAt  string
 			DatabaseID int
 			Labels     struct {
 				Nodes []struct {
@@ -322,6 +323,16 @@ w.waitUntilLimitIsRefreshed()
 
 }
 
+// Parse string to time.Time
+func timeConvert(GHUpdatedTime string) time.Time {
+	layout := "2006-01-02T15:04:05"
+	t, err := time.Parse(layout, GHUpdatedTime)
+	if err != nil {
+	    fmt.Println(err)
+	}
+	return t
+}
+
 // Parse and save github issues
 func (w *Worker) parseAndSaveIssues(issueData issueQueryWithBefore, repository *models.Repository, language *string, hasPreviousPage bool) {
 	issuesToCreate := models.Issues{}
@@ -337,6 +348,7 @@ func (w *Worker) parseAndSaveIssues(issueData issueQueryWithBefore, repository *
 			RepositoryID: repository.ID,
 			ProjectID:    repository.ProjectID,
 			Language:     nulls.String{String: strings.ToLower(*language), Valid: *language != ""},
+			GithubUpdatedAt: timeConvert(node.UpdatedAt),
 		}
 
 		// Parse github labels

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -334,7 +334,7 @@ func (w *Worker) getExtraIssues(name, owner *githubv4.String, before *string, re
 
 // Parse string to time.Time
 func timeConvert(GHUpdatedTime string) time.Time {
-	layout := "2006-01-02T15:04:05"
+	layout := "2006-01-02T15:04:05Z"
 	t, err := time.Parse(layout, GHUpdatedTime)
 	if err != nil {
 	    fmt.Println(err)


### PR DESCRIPTION
Continues from #23 
closes #23 

Original Desc

### Description of the Change
Added GitHubUpdatedAt field which is fetched from GitHub's GraphQL API "updatedAt". It is stored in the database at column GitHubUpdatedAt.

### Benefits
Now issues will be sorted using GitHubUpdatedAt field by default.

### Applicable Issues
Closes #5 
Closes #7
Closes #12